### PR TITLE
Updating apiVersion of Deployment and adding selector

### DIFF
--- a/my-deploy.yaml
+++ b/my-deploy.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-deploy
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+        app: deploy-app
   template:
     metadata:
       name: deploy-pod


### PR DESCRIPTION
Sir i am using the latest version of minikube and hence observed the apiVersion of Deployment Replica Set and Replica Controller are changed

**Api Versions:**
Deployment --> from  apps/v1beta1 to apps/v1

waiting for your response @aamirpinger  
student of CNC , PIAIC KARACHI